### PR TITLE
Renaming and docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ using Pkg
 Pkg.add("ProteinChains")
 ```
 
-## Examples
+## Quickstart
 
 The `ProteinChain` type is meant to only store a basic set of fields, from which some other properties might be derived.
 
@@ -30,19 +30,19 @@ julia> propertynames(chain)
 (:id, :atoms, :sequence, :numbering)
 ```
 
-To store additional properties, `annotate` can be used to attach persistent chain-level properties or indexable residue-level properties:
+To store additional properties, `addproperty` can be used to attach persistent chain-level properties or indexable residue-level properties:
 
 ```julia
 julia> chain = structure["A"]
 256-residue ProteinChain{Float64, @NamedTuple{}} (A)
 
-julia> annotated_chain = annotate(chain; taxid=ChainProperty(83332))
-256-residue ProteinChain{Float64, @NamedTuple{taxid::ChainProperty{Int64}}} (A)
+julia> new_chain = addproperty(chain; taxid=PersistentProperty(83332))
+256-residue ProteinChain{Float64, @NamedTuple{taxid::PersistentProperty{Int64}}} (A)
 
-julia> annotated_chain = annotate(annotated_chain; some_residue_property=ResidueProperty(rand(3,256))) # last dimension gets indexed
-256-residue ProteinChain{Float64, @NamedTuple{ORGANISM_TAXID::ChainProperty{Int64}, some_residue_property::ResidueProperty{Matrix{Float64}}}} (A)
+julia> new_chain = addproperty(new_chain; some_residue_property=IndexableProperty(rand(3,256))) # last dimension gets indexed
+256-residue ProteinChain{Float64, @NamedTuple{taxid::PersistentProperty{Int64}, some_residue_property::IndexableProperty{Matrix{Float64}}}} (A)
 
-julia> annotated_chain[1:100].some_residue_property
+julia> new_chain[1:100].some_residue_property
 3×100 Matrix{Float64}:
  0.273545  0.639173  0.92708   …  0.459441  0.196407  0.880034       
  0.981498  0.70263   0.279264     0.552049  0.89274   0.0328866      
@@ -51,6 +51,6 @@ julia> annotated_chain[1:100].some_residue_property
 
 ## See also
 
-- [Backboner.jl](https://github.com/MurrellGroup/Backboner.jl)
 - [BioStructures.jl](https://github.com/BioJulia/BioStructures.jl)
+- [Backboner.jl](https://github.com/MurrellGroup/Backboner.jl)
 - [PDBTools.jl](https://github.com/m3g/PDBTools.jl)

--- a/src/ProteinChains.jl
+++ b/src/ProteinChains.jl
@@ -14,8 +14,9 @@ export Atom
 @compat public (atom_name, atom_number, atom_coords)
 
 include("properties.jl")
-export ChainProperty, ResidueProperty
-export annotate
+export PersistentProperty, IndexableProperty
+export addproperty
+@compat public (AbstractProperty, NamedProperties)
 
 include("chain.jl")
 export ProteinChain

--- a/src/io/download.jl
+++ b/src/io/download.jl
@@ -1,6 +1,6 @@
 using Base.Filesystem
 
-const MAX_CACHE_ENTRIES = Ref{Int}(4)
+const MAX_CACHE_ENTRIES = 4
 const CACHE_DIR = Ref{Union{String,Nothing}}(nothing)
 
 function initialize_cache_dir()
@@ -12,14 +12,45 @@ end
 
 function manage_cache()
     entries = readdir(CACHE_DIR[])
-    while length(entries) > MAX_CACHE_ENTRIES[]
+    while length(entries) > MAX_CACHE_ENTRIES
         oldest_entry = entries[argmin([mtime(joinpath(CACHE_DIR[], entry)) for entry in entries])]
         rm(joinpath(CACHE_DIR[], oldest_entry))
         entries = readdir(CACHE_DIR[])
     end
 end
 
-function pdbentry(pdbid::AbstractString; format=BioStructures.MMCIFFormat, kwargs...)
+@doc raw"""
+    pdbentry(pdbid::AbstractString; format=MMCIFFormat, kwargs...)
+
+Keyword arguments get propagated to [`BioStructures.downloadpdb`](https://biojulia.dev/BioStructures.jl/stable/api/#BioStructures.downloadpdb-Tuple{AbstractString})
+
+Downloads are cached in a temporary directory up to $MAX_CACHE_ENTRIES times.
+
+## Examples
+
+```jldoctest
+julia> pdbentry("1EYE")
+[ Info: Downloading file from PDB: 1EYE
+1-chain ProteinStructure{Float64} "1EYE.cif"
+ 256-residue ProteinChain{Float64, @NamedTuple{}} (A)
+
+julia> pdb"1EYE" # convenience macro
+[ Info: File exists: 1EYE
+1-chain ProteinStructure{Float64} "1EYE.cif"
+ 256-residue ProteinChain{Float64, @NamedTuple{}} (A)
+
+julia> pdb"1EYE"A # string suffix to get a specific chain
+[ Info: File exists: 1EYE
+256-residue ProteinChain{Float64, @NamedTuple{}} (A)
+
+julia> pdb"1EYE"1 # integer suffix to specify "ba_number" keyword
+[ Info: Downloading file from PDB: 1EYE
+2-chain ProteinStructure{Float64} "1EYE_ba1.cif"
+ 256-residue ProteinChain{Float64, @NamedTuple{}} (A)
+ 256-residue ProteinChain{Float64, @NamedTuple{}} (A-2)
+```
+"""
+function pdbentry(pdbid::AbstractString; format=MMCIFFormat, kwargs...)
     initialize_cache_dir()
     path = BioStructures.downloadpdb(pdbid; dir=CACHE_DIR[], format=format, kwargs...)
     manage_cache()

--- a/src/io/read.jl
+++ b/src/io/read.jl
@@ -10,14 +10,14 @@ get_sequence(residues::Vector{BioStructures.AbstractResidue}) = join(map(onelett
 get_atom(residue::BioStructures.AbstractResidue, name::AbstractString) =
     BioStructures.collectatoms(residue, a -> BioStructures.atomnameselector(a, [name])) |> only
 
-Atom{T}(atom::BioStructures.Atom) where T = convert(Atom{T}, Atom(atom.name, atom.element, atom.coords))
-Atom{T}(atom::BioStructures.DisorderedAtom) where T = Atom{T}(BioStructures.defaultatom(atom))
+Base.convert(::Type{Atom{T}}, atom::BioStructures.Atom) where T = convert(Atom{T}, Atom(atom.name, atom.element, atom.coords))
+Base.convert(::Type{Atom{T}}, atom::BioStructures.DisorderedAtom) where T = convert(Atom{T}, BioStructures.defaultatom(atom))
 
 function get_atoms(::Type{Atom{T}}, residues::Vector{BioStructures.AbstractResidue}) where T
     atoms = Vector{Atom{Float64}}[]
     for residue in residues
         residue = residue isa BioStructures.DisorderedResidue ? BioStructures.defaultresidue(residue) : residue
-        residue_atoms = map(Atom{T}, BioStructures.collectatoms(residue))
+        residue_atoms = map(atom -> convert(Atom{T}, atom), BioStructures.collectatoms(residue))
         push!(atoms, residue_atoms)
     end
     return atoms
@@ -35,7 +35,7 @@ end
 
 function ProteinStructure{T}(struc::BioStructures.MolecularStructure; mmcifdict=nothing) where T
     proteinchains = ProteinChain{T}[]
-    atoms = map(Atom{T}, BioStructures.collectatoms(BioStructures.collectresidues(struc, !backbone_residue_selector)))
+    atoms = map(atom -> convert(Atom{T}, atom), BioStructures.collectatoms(BioStructures.collectresidues(struc, !backbone_residue_selector)))
     for model in struc, chain in model
         push!(proteinchains, ProteinChain{T}(chain))
     end

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -2,18 +2,50 @@ abstract type AbstractProperty end
 
 Base.getindex(p::AbstractProperty) = p.value
 
-struct ChainProperty{T} <: AbstractProperty
+"""
+    PersistentProperty(value)
+
+A property of arbitrary type that persists after residue indexing of a chain.
+
+```jldoctest
+julia> chain = addproperty(pdb"1ASS"A; x=PersistentProperty(1));
+
+julia> chain.x == chain[1:10].x
+true
+```
+"""
+struct PersistentProperty{T} <: AbstractProperty
     value::T
 end
 
-Base.getindex(prop::ChainProperty, ::AbstractVector) = prop
+Base.getindex(p::PersistentProperty, ::AbstractVector) = p
 
-struct ResidueProperty{T<:AbstractArray} <: AbstractProperty
+"""
+    IndexableProperty <: AbstractProperty
+
+    IndexableProperty(value::AbstractArray)
+
+An `AbstractArray` property with size `(dims..., length(chain))`, and
+residue indexing of the chain being propagated to the last dimension of the array.
+
+```jldoctest
+julia> chain = pdb"1ASS"A;
+
+julia> chain = addproperty(pdb"1ASS"A; y=IndexableProperty(rand(2,152)));
+
+julia> chain.y == chain[1:10].y
+false
+
+julia> chain.y[:,1:10] == chain[1:10].y
+true
+```
+"""
+struct IndexableProperty{T<:AbstractArray} <: AbstractProperty
     value::T
 end
 
-Base.getindex(prop::ResidueProperty, i::AbstractVector) = selectdim(prop.value, ndims(prop.value), i) |> ResidueProperty
+Base.getindex(p::IndexableProperty, i::AbstractVector) = selectdim(p.value, ndims(p.value), i) |> IndexableProperty
 
 const NamedProperties{names} = NamedTuple{names,<:Tuple{Vararg{AbstractProperty}}}
 
-function annotate end
+function addproperty end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ using Test
 
     @testset "ProteinStructure" begin
         chain = ProteinChain("A", get_atoms(ProteinChains.Backbone(rand(3, 3, 5))), "AMINO", collect(1:5))
-        structure = ProteinStructure("1CHN", Atom{Float64}[], [chain])
+        structure = ProteinStructure("1CHN", Atom{Float64}[], [chain, chain])
         @test structure[1] === chain
         @test structure["A"] === chain
     end
@@ -39,7 +39,7 @@ using Test
     @testset "store" begin
         mktempdir() do dir
             filename = joinpath(dir, "store.h5")
-            structures = [annotate(pdb"1EYE", :backbone), annotate(pdb"3HFM", :backbone, :bond_lengths)]
+            structures = [addproperty(pdb"1EYE", :backbone), addproperty(pdb"3HFM", :backbone, :bond_lengths)]
             ProteinChains.serialize(filename, structures)
             structures_copy = ProteinChains.deserialize(filename)
             @test structures == structures_copy


### PR DESCRIPTION
- I renamed `annotate` to `addproperty`, `ChainProperty` to `PersistentProperty`, `ResidueProperty` to `IndexableProperty`.
- Removed `ProteinStructure`'s chain numbering field, as any possible use for it could be achieved with `PersistentProperty`s. ProteinStructure serialization now simply enumerates the chains when creating group names.
- Added more docstrings